### PR TITLE
Fix for dd argument.

### DIFF
--- a/raspiwrite.py
+++ b/raspiwrite.py
@@ -166,7 +166,7 @@ class transferInBackground (threading.Thread): 	#Runs the dd command in a thread
    def run ( self ):
 	global SDsnip
 	global path
-	copyString = 'dd bs=1m if=%s of=%s' % (path,SDsnip)
+	copyString = 'dd bs=1M if=%s of=%s' % (path,SDsnip)
 	print 'Running ' + copyString + '...'
 	print getoutput(copyString)
 	print 'done!'


### PR DESCRIPTION
Hi,

Your script gives this error, because the argument to dd was 1m, and not 1M:

Waitingdd: invalid number ‘1m’
