### PR TITLE
Fixed broken script on OSX

### DIFF
--- a/raspiwrite.py
+++ b/raspiwrite.py
@@ -172,7 +172,8 @@ class transferInBackground (threading.Thread): 	#Runs the dd command in a thread
    def run ( self ):
 	global SDsnip
 	global path
-	copyString = 'dd bs=1M if=%s of=%s' % (path,SDsnip)
+	# bs = 1048576 = 1024*1024 (1m on OSX / 1M on linux)
+	copyString = 'dd bs=1048576 if=%s of=%s' % (path,SDsnip)
 	print 'Running ' + copyString + '...'
 
 	print getoutput(copyString)
@@ -268,7 +269,12 @@ def transfer(file,archiveType,obtain,SD,URL):	#unzips the disk image
 	if (SD.find("/dev/mmcblk") + 1):
 		SDsnip = "/dev/mmcblk" + SD[11]
 	else:
-		SDsnip =  SD.replace(' ', '')[:-1]
+		if OS[0] != 'Darwin':
+		        # Remove 'Y' from /dev/sdXY
+		        SDsnip =  SD.replace(' ', '')[:-1]
+		else:
+		        # Remove 'sY' from /dev/diskXsY
+		        SDsnip =  SD.replace(' ', '')[:-2]
 	print path
 	print '\n\n###################################################################'
 	print 'About to start the transfer procedure, here is your setup:'


### PR DESCRIPTION
- Made dd argument platform independent:
  bs shall be 1m with default (BSD) dd on OSX but 1M with GNU dd (linux/OSX)
- Chop 's' + minor number from partition name to get device name on OSX
