### PR TITLE
Syntax errors running on Python 2.7 using Mac OS X 10.8.2

### DIFF
--- a/raspiwrite.py
+++ b/raspiwrite.py
@@ -174,7 +174,7 @@ class transferInBackground (threading.Thread): 	#Runs the dd command in a thread
 	global path
 	if OS[0] != 'Darwin':
 		copyString = 'dd bs=1M if=%s of=%s' % (path,SDsnip)
-	else
+	else:
 		copyString = 'dd bs=1m if=%s of=%s' % (path,SDsnip)
 	print 'Running ' + copyString + '...'
 
@@ -272,10 +272,10 @@ def transfer(file,archiveType,obtain,SD,URL):	#unzips the disk image
 		SDsnip = "/dev/mmcblk" + SD[11]
 	else:
 		if OS[0] != 'Darwin': 
-        	SDsnip =  SD.replace(' ', '')[:-1]
+			SDsnip =  SD.replace(' ', '')[:-1]
  		else:
  			# remove weird partition notation in OS X partition names
-        	SDsnip =  SD.replace(' ', '')[:-2]
+			SDsnip =  SD.replace(' ', '')[:-2]
 
 	print path
 	print '\n\n###################################################################'


### PR DESCRIPTION
For whatever reason, I needed to make the attached changes in order to run `raspiwrite.py` on my environment. Figured I'd create a pull request and document the syntax errors I ran into in case others run into similar issues.

✪  git clone https://github.com/exaviorn/RasPiWrite.git              1354378953
Cloning into 'RasPiWrite'...
remote: Counting objects: 64, done.
remote: Compressing objects: 100% (36/36), done.
remote: Total 64 (delta 30), reused 62 (delta 28)
Unpacking objects: 100% (64/64), done.
✪  ./raspiwrite.py                                                   1354378971
  File "./raspiwrite.py", line 177
    else
       ^
SyntaxError: invalid syntax

✪  ./raspiwrite.py                                              1354379016
  File "./raspiwrite.py", line 275
    SDsnip =  SD.replace(' ', '')[:-1]
         ^
IndentationError: expected an indented block

✪  ./raspiwrite.py                                              1354379115
  File "./raspiwrite.py", line 278
    SDsnip =  SD.replace(' ', '')[:-2]
         ^
IndentationError: expected an indented block
