### PR TITLE
Fix syntax error

### DIFF
--- a/raspiwrite.py
+++ b/raspiwrite.py
@@ -174,7 +174,7 @@ class transferInBackground (threading.Thread): 	#Runs the dd command in a thread
 	global path
 	if OS[0] != 'Darwin':
 		copyString = 'dd bs=1M if=%s of=%s' % (path,SDsnip)
-	else
+	else:
 		copyString = 'dd bs=1m if=%s of=%s' % (path,SDsnip)
 	print 'Running ' + copyString + '...'
 


### PR DESCRIPTION
[RasPiWrite-master]$ sudo ./raspiwrite.py 
Password:
  File "./raspiwrite.py", line 177
    else
       ^
SyntaxError: invalid syntax
